### PR TITLE
Comillas simples en comando del package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --color",
-    "format": "prettier --write 'src/**/*.{ts,tsx,scss,css,json}'",
+    "format": "prettier --write \"src/**/*.{ts,tsx,scss,css,json}\"",
     "isready": "npm run format && npm run lint && npm run build"
   },
   "eslintConfig": {


### PR DESCRIPTION
Las comillas simples causan problemas en windows, en cambio de este modo anda piola en windows y linux